### PR TITLE
fixed find_many so it will return paris objects instead of ORMWrapper

### DIFF
--- a/src/paris/orm/ORMWrapper.php
+++ b/src/paris/orm/ORMWrapper.php
@@ -139,8 +139,8 @@ class ORMWrapper extends ORM
   {
     $results = parent::find_many();
 
-    foreach ($results as &$result) {
-      $result = $this->_create_model_instance($result);
+    foreach ($results as $counter => $result) {
+      $results[$counter] = $this->_create_model_instance($result);
     }
 
     return $results;


### PR DESCRIPTION
when return_result_sets is set to true

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/paris/7)

<!-- Reviewable:end -->
